### PR TITLE
fix issue with resetting on change of state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -775,7 +775,7 @@ export default class extends Component {
         {...this.props}
         {...this.scrollViewPropOverrides()}
         contentContainerStyle={[styles.wrapperIOS, this.props.style]}
-        contentOffset={this.state.offset}
+        contentOffset={this.fullState().offset}
         onScrollBeginDrag={this.onScrollBegin}
         onMomentumScrollEnd={this.onScrollEnd}
         onScrollEndDrag={this.onScrollEndDrag}


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- If yes, which issue (fix #number) ? #1053

### Is it a new feature ?
- No

### Describe what you've done:

Change `contentOffset={this.state.offset}` to `contentOffset={this.fullState().offset}`

### How to test it ?

Add slides with state changes, change state
